### PR TITLE
Fix caller determination in fixPath()

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,19 @@ cache:
     - $HOME/.composer/cache
 
 language: php
-php:
-  - 5.4
-  - 5.5
-  - 5.6
-  - 7.0
-  - hhvm
+jobs:
+  include:
+    - php: 5.4
+      dist: trusty
+    - php: 5.5
+      dist: trusty
+    - php: 5.6
+    - php: 7.0
+    - php: 7.1
+    - php: 7.2
+    - php: 7.3
+    - php: 7.4
+    - php: hhvm
 
 matrix:
   allow_failures:
@@ -25,8 +32,8 @@ install:
 
 script:
   - cd tests
-  - phpunit --configuration phpunit.xml
+  - ../vendor/bin/phpunit --configuration phpunit.xml
 
   # Create coverage report
-  - sh -c "if [ "$TRAVIS_PHP_VERSION" != "7.0" ] && [ '$TRAVIS_PHP_VERSION' != 'hhvm' ]; then wget https://scrutinizer-ci.com/ocular.phar; fi"
-  - sh -c "if [ "$TRAVIS_PHP_VERSION" != "7.0" ] && [ '$TRAVIS_PHP_VERSION' != 'hhvm' ]; then php ocular.phar code-coverage:upload --format=php-clover clover.xml; fi"
+  - sh -c "if [ "$TRAVIS_PHP_VERSION" = "5.6" ]; then wget https://scrutinizer-ci.com/ocular.phar; fi"
+  - sh -c "if [ "$TRAVIS_PHP_VERSION" = "5.6" ]; then php ocular.phar code-coverage:upload --format=php-clover clover.xml; fi"

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
 		"php": ">=5.4"
 	},
 	"require-dev": {
-		"phpunit/phpunit": "4.8.*"
+		"phpunit/phpunit": "^4 || ^5 || ^6 || ^7"
 	},
 	"autoload": {
 		"psr-4": {

--- a/tests/IncludePath/IncludePathTest.php
+++ b/tests/IncludePath/IncludePathTest.php
@@ -22,6 +22,9 @@ class IncludePathTests extends TestCase {
 		/** @var callable $method */
 		$method = include '../data/addOne.php';
 
+		// Make sure a normal file_get_contents() works as well.
+		$this->assertNotFalse(file_get_contents('../data/addOne.php'));
+
 		$instance->tearDown();
 
 		$this->assertEquals(3, $method(1));

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -7,7 +7,7 @@
 
 namespace Icewind\Interceptor\Tests;
 
-abstract class TestCase extends \PHPUnit_Framework_TestCase {
+abstract class TestCase extends \PHPUnit\Framework\TestCase {
 	private $tmpFiles = [];
 
 	public function tearDown() {


### PR DESCRIPTION
Depending on whether `stream_open()` is called via include or not, the `'file'` may be either on `$backtrace[0]` or `$backtrace[1]`. Handle both cases.